### PR TITLE
Ensure loading state resets for cart updates

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -107,8 +107,12 @@ export default function AdminDashboard() {
         original_price: "",
         stock_quantity: "",
       });
-    } catch (err: any) {
-      setMessage("❌ Error adding product: " + err.message);
+    } catch (err) {
+      if (err instanceof Error) {
+        setMessage("❌ Error adding product: " + err.message);
+      } else {
+        setMessage("❌ Error adding product");
+      }
     } finally {
       setSubmitting(false);
     }

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -57,7 +57,7 @@ export default function CartPage() {
 
     // Map joined arrays to single objects as expected by CartItemRow
     setCart(
-      (data || []).map((item: any) => ({
+      (data || []).map((item) => ({
         ...item,
         products: Array.isArray(item.products) ? item.products[0] : item.products,
         product_variants: Array.isArray(item.product_variants) ? item.product_variants[0] : item.product_variants,
@@ -76,14 +76,27 @@ export default function CartPage() {
       .from("cart_items")
       .update({ quantity })
       .eq("id", itemId);
+    if (error) {
+      console.error("Error updating quantity:", error);
+      setLoading(false);
+      return;
+    }
 
-    if (!error) await fetchCart();
+    await fetchCart();
+    setLoading(false);
   }
 
   async function removeItem(itemId: string) {
     setLoading(true);
     const { error } = await supabase.from("cart_items").delete().eq("id", itemId);
-    if (!error) await fetchCart();
+    if (error) {
+      console.error("Error removing item:", error);
+      setLoading(false);
+      return;
+    }
+
+    await fetchCart();
+    setLoading(false);
   }
 
   const total = cart.reduce((sum, item) => {


### PR DESCRIPTION
## Summary
- Reset loading state after updating quantity or removing items from cart and log errors
- Handle admin dashboard submission errors without using `any`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688eb4b9e61c8323aa6bd3a72c5fa2dc