### PR TITLE
chore: remove duplicate import and unused fonts

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,15 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
-
-
 import "./globals.css";
 import { Playfair_Display, Poppins } from "next/font/google";
 
-const playfair = Playfair_Display({ subsets: ["latin"], weight: ["400", "700", "900"] });
+const playfair = Playfair_Display({
+  subsets: ["latin"],
+  weight: ["400", "700", "900"],
+  variable: "--font-playfair",
+});
 const poppins = Poppins({ subsets: ["latin"], weight: ["400", "500", "700"] });
 
-export const metadata = {
+export const metadata: Metadata = {
   title: "Liquor Store",
   description: "Online Liquor Store",
 };
@@ -17,36 +17,9 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className={`${poppins.className} bg-gray-50 text-gray-800`}>
+      <body className={`${poppins.className} ${playfair.variable} bg-gray-50 text-gray-800`}>
         {children}
       </body>
     </html>
   );
 }
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
-
-
-// export default function RootLayout({
-//   children,
-// }: Readonly<{
-//   children: React.ReactNode;
-// }>) {
-//   return (
-//     <html lang="en">
-//       <body
-//         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-//       >
-//         {children}
-//       </body>
-//     </html>
-//   );
-// }


### PR DESCRIPTION
## Summary
- clean up layout font imports
- remove duplicate CSS import

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in src/app/admin/dashboard/page.tsx, src/app/cart/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_688eb4b2f4d08323ad1a22476634adf0