### PR TITLE
Fix star rating to display for zero ratings

### DIFF
--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -84,7 +84,7 @@ export default async function ProductPage({ params }: ProductPageProps) {
               )}
 
               {/* Star Rating */}
-              {product.rating && product.reviews_count !== null && (
+              {product.rating !== null && product.reviews_count !== null && (
                 <StarRating
                   rating={product.rating}
                   reviewsCount={product.reviews_count}


### PR DESCRIPTION
## Summary
- Ensure product star rating renders when rating is zero by checking for null values.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_688eb4bc23408323bd7c1caa8eedcca9